### PR TITLE
Add command 'password'

### DIFF
--- a/src/commands/utils/password.ts
+++ b/src/commands/utils/password.ts
@@ -1,0 +1,61 @@
+import Command from '../../classes/command.class'
+import Logger from '../../classes/logger.class'
+import { not } from '../../helpers/not.helper'
+import { copyToClipboard } from '../../utils/copyToClipboard'
+
+function createRandomStrongPassword(length = 16) {
+  const uppercaseLetters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  const lowercaseLetters = uppercaseLetters.toLowerCase()
+  const digits = '0123456789'
+  const specialCharacters = '!@#$%^&*()-_=+[]{}|;:,.<>?'
+
+  const allCharacters =
+    uppercaseLetters + lowercaseLetters + digits + specialCharacters
+  let password = ''
+
+  // Ensure that at least one character from each category is included
+  password +=
+    uppercaseLetters[Math.floor(Math.random() * uppercaseLetters.length)]
+  password +=
+    lowercaseLetters[Math.floor(Math.random() * lowercaseLetters.length)]
+  password += digits[Math.floor(Math.random() * digits.length)]
+  password +=
+    specialCharacters[Math.floor(Math.random() * specialCharacters.length)]
+
+  // Fill the rest of the password with random characters from all categories
+  for (let i = 4; i < length; i++) {
+    password += allCharacters[Math.floor(Math.random() * allCharacters.length)]
+  }
+
+  // Shuffle the password to ensure randomness
+  return password
+    .split('')
+    .sort(() => 0.5 - Math.random())
+    .join('')
+}
+
+async function execute(args: string[], flags: string[]) {
+  const verbose = flags.includes('verbose')
+  const shouldCopy = not(flags.includes('no-copy'))
+  const password = createRandomStrongPassword()
+
+  Logger.cyan('Generating your super secure password...')
+
+  // Log the password to console if verbose flag is set
+  // If --no-copy flag is set, log the password in the terminal
+  if (!shouldCopy || verbose) Logger.newline().cyan(password)
+
+  if (shouldCopy) {
+    try {
+      await copyToClipboard(password)
+      Logger.newline().success('Copied your new password to clipboard!')
+    } catch (error) {
+      Logger.error(error as any)
+      Logger.warning('Use --no-copy to reveal the password in the terminal')
+    }
+  }
+}
+
+const gitconf = new Command('password').setExecutable(execute) //.setSetup(setup)
+
+export default gitconf

--- a/src/helpers/command.helper.ts
+++ b/src/helpers/command.helper.ts
@@ -45,7 +45,7 @@ export async function getCommands() {
 
 // Check if an argument can be interpreted as a flag
 export function getFlag(arg: string) {
-  const match = arg.match(/^[-]{1,2}(\w*)/)
+  const match = arg.match(/^[-]{1,2}([\w-]*)/)
   const flag = match?.[1]
 
   return { isFlag: match !== null, flag }

--- a/src/utils/copyToClipboard.ts
+++ b/src/utils/copyToClipboard.ts
@@ -1,0 +1,28 @@
+import os from 'os'
+import { not } from '../helpers/not.helper'
+import { spawn } from 'child_process'
+
+// Structure: [command, ...[arguments]]
+const COPY_COMMANDS: Record<string, string[]> = {
+  darwin: ['pbcopy'],
+  win32: ['clip'],
+  linux: ['xclip', '-selection', 'clipboard'],
+}
+
+export async function copyToClipboard(text: string) {
+  const platform = os.platform()
+
+  // Catch any non-supported platforms
+  if (not(platform in COPY_COMMANDS)) {
+    throw new Error(`Unsupported platform: ${platform}`)
+  }
+
+  // Deconstruct command and args
+  const [command, ...args] = COPY_COMMANDS[platform]
+
+  // Spawn child process
+  const child = spawn(command, args)
+
+  // Write text to be copied to stdin stream
+  child.stdin.end(text)
+}


### PR DESCRIPTION
Add command 'password'

Flag --verbose for logging the password to the console.

Flag --no-copy to skip copying to clipboard, useful when on a platform that is not supported for copying to clipboard.

--no-copy will also work as verbose, logging the password to the console.